### PR TITLE
Factor out a test sandbox module

### DIFF
--- a/test/d3sandbox.js
+++ b/test/d3sandbox.js
@@ -1,0 +1,41 @@
+/**
+ * This is a test helper which loads all the relevant JS into a new context.
+ */
+
+var vm = require("vm"),
+    fs = require("fs"),
+    jsdom = require("jsdom");
+
+// In dependency order.
+var js_files = [
+  "node_modules/d3/d3.min.js",
+  "node_modules/underscore/underscore-min.js",
+  "d3.stacked-bar-chart.js"
+];
+
+var concatenatedJs = js_files.map(function(path) {
+  return fs.readFileSync(path);
+}).join("\n");
+
+/** @constructor */
+var d3sandbox = function() {
+  this.document = jsdom.jsdom("<html><head></head><body></body></html>");
+  this.sandbox = {
+    console: console,
+    Date: Date,
+    document: this.document,
+    window: this.document.createWindow()
+  };
+
+  vm.runInNewContext(concatenatedJs, this.sandbox);
+
+  // convenience accessors
+  this.d3 = this.sandbox.d3;
+  this.window = this.sandbox.window;
+}
+
+module.exports = {
+  create: function() {
+    return new d3sandbox();
+  }
+};

--- a/test/simple.js
+++ b/test/simple.js
@@ -1,21 +1,21 @@
 var assert = require("assert"),
-    jsdom = require("jsdom").jsdom,
-    _ = require("underscore");
+    _ = require("underscore"),
+    jquery = require("jquery"),
+    d3sandbox = require("./d3sandbox");
 
-// TODO(danvk): figure out if it's possible to use Node's require() here.
-// TODO(danvk): wrap this up in a test helper module.
-var document = jsdom('<html><head>' + 
-    '<script src="../node_modules/d3/d3.min.js"></script>' + 
-    '<script src="../node_modules/underscore/underscore-min.js"></script>' + 
-    '<script src="../d3.stacked-bar-chart.js"></script>' + 
-    '</head><body></body></html>');
-
-var window = document.parentWindow;
-var $ = require("jquery")(window);
 
 describe('d3.stacked-bar-chart', function() {
+  var $, document, d3;
+
+  beforeEach(function() {
+    var sandbox = d3sandbox.create();
+    $ = jquery(sandbox.window);
+    d3 = sandbox.d3;
+    document = sandbox.document;
+  });
+
   it('should have the right defaults', function() {
-    var chart = window.d3.chart.stackedBars();
+    var chart = d3.chart.stackedBars();
     assert.equal(960, chart.width());
     assert.equal(500, chart.height());
   });
@@ -31,7 +31,7 @@ describe('d3.stacked-bar-chart', function() {
     data[2].name = 'somaticsniper.chr20';
 
     var sum = function(list) { return list.reduce(function(a,b){return a + b;}, 0); };
-    var chart = window.d3.chart.stackedBars()
+    var chart = d3.chart.stackedBars()
         .title("Caller Concordance")
         .yAxisTitle("Number of Variants Called")
         .sectionBinDesc("callers in concordance")
@@ -48,7 +48,7 @@ describe('d3.stacked-bar-chart', function() {
     var div = document.createElement('div');
     div.setAttribute('id', 'conc_div');
     document.body.appendChild(div);
-    window.d3.select('#conc_div').datum(data).call(chart);
+    d3.select('#conc_div').datum(data).call(chart);
 
     var sumTexts = $.makeArray($('g.bar text', div)).map(function(x) { return $(x).text()});
     assert.deepEqual(["1,527", "1,653", "1,680"], sumTexts);


### PR DESCRIPTION
This hides most of the nastiness inside a test helper module.

We're using vm.runInNewContext() now, which is exactly what smash does under the hood for d3.
